### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: Lint
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/BC-Robotics-4504/2026-Season/security/code-scanning/1](https://github.com/BC-Robotics-4504/2026-Season/security/code-scanning/1)

To fix the issue, we should add a `permissions` block to the workflow, either at the root level (recommended, as there is only one job) or at the job level. Given that the workflow only checks out code and runs Ruff lint/format checks, the minimal permission required is `contents: read`. This restricts the GITHUB_TOKEN to only read-access to the repository contents, preventing any unintended write operations or escalation. The change should be made near the top of the YAML file, after the workflow `name:` and before or after the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
